### PR TITLE
Replace FlutterActivity in favor of Activity

### DIFF
--- a/android/src/main/kotlin/com/snnafi/media_store_plus/MediaStorePlusPlugin.kt
+++ b/android/src/main/kotlin/com/snnafi/media_store_plus/MediaStorePlusPlugin.kt
@@ -41,7 +41,7 @@ fun String.capitalized(): String {
 class MediaStorePlusPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
         PluginRegistry.ActivityResultListener {
 
-    private var activity: FlutterActivity? = null
+    private var activity: Activity? = null
     private lateinit var channel: MethodChannel
     private lateinit var result: io.flutter.plugin.common.MethodChannel.Result
 
@@ -143,7 +143,7 @@ class MediaStorePlusPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-        this.activity = binding.activity as FlutterActivity
+        this.activity = binding.activity
         binding.addActivityResultListener(this)
     }
 


### PR DESCRIPTION
When using other libraries, such as local_auth, which requires the MainActivity to inherit from `FlutterFragmentActivity` instead of `FlutterActivity`, me and my team were facing a crash due to a casting error, which caused a NullPointerException as shown below:

```
W/libc    (13413): Access denied finding property "sys.perf.boostopt"
D/DirName (13413): Download
E/Exception(13413): null
E/Exception(13413): java.lang.NullPointerException
E/Exception(13413): 	at com.snnafi.media_store_plus.MediaStorePlusPlugin.getUriFromDisplayName(MediaStorePlusPlugin.kt:358)
E/Exception(13413): 	at com.snnafi.media_store_plus.MediaStorePlusPlugin.deleteFileUsingDisplayName(MediaStorePlusPlugin.kt:311)
E/Exception(13413): 	at com.snnafi.media_store_plus.MediaStorePlusPlugin.createOrUpdateFile(MediaStorePlusPlugin.kt:269)
E/Exception(13413): 	at com.snnafi.media_store_plus.MediaStorePlusPlugin.saveFile(MediaStorePlusPlugin.kt:181)
E/Exception(13413): 	at com.snnafi.media_store_plus.MediaStorePlusPlugin.onMethodCall(MediaStorePlusPlugin.kt:66)
E/Exception(13413): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:258)
E/Exception(13413): 	at io.flutter.embedding.engine.dart.DartMessenger.invokeHandler(DartMessenger.java:295)
E/Exception(13413): 	at io.flutter.embedding.engine.dart.DartMessenger.lambda$dispatchMessageToQueue$0$io-flutter-embedding-engine-dart-DartMessenger(DartMessenger.java:322)
E/Exception(13413): 	at io.flutter.embedding.engine.dart.DartMessenger$$ExternalSyntheticLambda0.run(Unknown Source:12)
E/Exception(13413): 	at android.os.Handler.handleCallback(Handler.java:942)
E/Exception(13413): 	at android.os.Handler.dispatchMessage(Handler.java:99)
E/Exception(13413): 	at android.os.Looper.loopOnce(Looper.java:226)
E/Exception(13413): 	at android.os.Looper.loop(Looper.java:313)
E/Exception(13413): 	at android.app.ActivityThread.main(ActivityThread.java:8757)
E/Exception(13413): 	at java.lang.reflect.Method.invoke(Native Method)
E/Exception(13413): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
E/Exception(13413): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
```

In order to fix it, I simply switched it to a generic Activity, since the methods used didn't require it to be a FlutterActivity. I've tested it against the example by switching it to a `FlutterFragmentActivity` and it worked flawlessly.