### PR TITLE
Set namespace in build.gradle for AGP 8.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.snnafi.media_store_plus'
+    }
     compileSdkVersion 33
 
     compileOptions {


### PR DESCRIPTION
AGP 8.0 requires the namespace to be set here:

https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl

This change gates it behind a `hasProperty` check like the official Flutter templates now do:

https://github.com/flutter/flutter/commit/31a665c3eb72318e7fa9e4e7f1756422561eacff

Fixes #12.